### PR TITLE
feat: Add Telegram notifications for session events and fix runtime e…

### DIFF
--- a/src/tomato_ai/handlers.py
+++ b/src/tomato_ai/handlers.py
@@ -35,8 +35,7 @@ def send_telegram_notification_on_start(event: events.SessionStarted):
     Sends a telegram notification when a session starts.
     """
     if (notifier := telegram.get_telegram_notifier()) and settings.TELEGRAM_CHAT_ID:
-        loop = asyncio.get_running_loop()
-        loop.create_task(
+        asyncio.run(
             notifier.send_message(
                 chat_id=settings.TELEGRAM_CHAT_ID,
                 message=f"Pomodoro session {event.session_id} started!",


### PR DESCRIPTION
…rror

This commit introduces Telegram notifications for when a Pomodoro session starts and when it is completed.

The notifications are triggered by events on the event bus. This decouples the notification logic from the application's core domain logic, making the system more modular and extensible.

This commit also includes a fix for a `RuntimeError: no running event loop` that occurred when creating a new session. The error was caused by calling `asyncio.get_running_loop()` from a synchronous endpoint handler running in a separate thread. The fix is to use `asyncio.run()` instead, which correctly handles the creation of a new event loop in that context.

Changes in this commit:
- Added `send_telegram_notification_on_start` and `send_telegram_notification` handlers to send notifications for `SessionStarted` and `SessionCompleted` events.
- Registered the new handlers in the application's bootstrap process.
- Replaced the direct Telegram notification in the FastAPI endpoint with the publishing of a `SessionCompleted` event.
- Fixed the `send_telegram_notification_on_start` handler to use `asyncio.run()` to avoid a `RuntimeError`.